### PR TITLE
Tom safire pr

### DIFF
--- a/compiler/codegen/gen_hostapp_class.cc
+++ b/compiler/codegen/gen_hostapp_class.cc
@@ -386,6 +386,11 @@ void genHostAppHeader(const string &hostClassFileName,
 		     "cudaStream_t stream = 0, int deviceId = -1") + ";");
   f.add("");
 
+  //setAppName function calls the app driver to set the app name
+  f.add(genFcnHeader("void", "setAppName", "const char* name"));
+  f.add("{ driver->setAppName(name); }");
+  f.add("");
+
   // getNBlocks() function calls the app driver to get # of active blocks
   f.add(genFcnHeader("int", "getNBlocks", ""));
   f.extend(" const");
@@ -436,6 +441,7 @@ void genHostAppHeader(const string &hostClassFileName,
   
   f.emit(hostClassFileName);
 }
+
 
 //
 // @brief generate the constructor for the host app in its own file

--- a/compiler/options.cc
+++ b/compiler/options.cc
@@ -18,7 +18,7 @@
 
 using namespace std;
 
-const char OptionList[] = ":a:DhH:I:Ko:S:t:v";
+const char OptionList[] = ":Q:a:DhH:I:Ko:S:t:v";
 
 CommandOptions options;
 
@@ -47,6 +47,10 @@ static void printUsage()
        << " -t <#>\n"
        << "   number of threads per block for the generated application\n"
        << "    (default " << options.threadsPerBlock << ")\n"
+       << "\n"
+       << " -Q <#>\n"
+       << "   queue scaling mulitpler for each node\n"
+       << "    (default " << options.queueScaler << ", minimum 2)\n"
        << "\n"
        << " -H <#>\n"
        << "   size of the device heap in MEGAbytes\n"
@@ -125,6 +129,16 @@ bool parseCommandLine(int argc, char **argv)
 	      if (options.deviceHeapSize < 1024 * 1024)
 		{
 		  cerr << "ERROR: device heap must be >= 1 MB"
+		       << endl;
+		  return false;
+		}
+	      break;
+
+	    case 'Q':
+	      options.queueScaler = stoi(optarg);
+	      if (options.queueScaler < 2)
+		{
+		  cerr << "ERROR: queue scaler must be greater then 2"
 		       << endl;
 		  return false;
 		}

--- a/mercator-rules.txt
+++ b/mercator-rules.txt
@@ -6,6 +6,7 @@
 # Copyright (C) 2018 Washington University in St. Louis; all rights reserved.
 
 set(MERCATOR_CC ${MERCATOR_ROOT_DIR}/bin/mercator)
+set(MERCATOR_FLAGS )
 
 # add_mercator_app()
 # Construct a MERCATOR application from sources
@@ -41,7 +42,7 @@ function(add_mercator_app)
 
    # teach cmake how to build the genenerated files from the spec
    add_custom_command(OUTPUT ${GENERATED_CUFILES} ${GENERATED_CUHFILES}
-	COMMAND ${MERCATOR_CC} -a ${appname} ${CMAKE_CURRENT_SOURCE_DIR}/${ADD_MERCATOR_SPECFILE}
+	COMMAND ${MERCATOR_CC} ${MERCATOR_FLAGS} -a ${appname} ${CMAKE_CURRENT_SOURCE_DIR}/${ADD_MERCATOR_SPECFILE}
 	DEPENDS ${ADD_MERCATOR_SPECFILE}
         COMMENT "Compiling MERCATOR spec file ${ADD_MERCATOR_SPECFILE}"
    )

--- a/runtime/hostCode/AppDriver.cuh
+++ b/runtime/hostCode/AppDriver.cuh
@@ -9,8 +9,9 @@
 // Copyright (C) 2018 Washington University in St. Louis; all rights reserved.
 //
 
-#include <cstddef>
 #include <iostream>
+#include <cstddef>
+#include <cstring>
 
 // profiling
 #ifdef PROFILE_TIME
@@ -50,6 +51,13 @@ namespace Mercator  {
     int getNBlocks() const { return nBlocks; }
     
     
+    void setAppName(const char* name) 
+    { 
+      int len = strlen(name) + 1;
+      appName = new char [len];
+      memcpy(appName, name, len);
+    }
+    
     // @brief constructor sets up the device context
     //
     // @param stream CUDA stream in which to run
@@ -58,7 +66,8 @@ namespace Mercator  {
     AppDriver(cudaStream_t istream,
 	      int ideviceId)
       : stream(istream),
-	deviceId(ideviceId)
+	deviceId(ideviceId),
+	appName(0)
     {
       using namespace std;
       
@@ -272,7 +281,7 @@ namespace Mercator  {
     ~AppDriver()
     {
       using namespace std;
-
+      
       // switch to our device
       int prevDeviceId = switchDevice(deviceId);
       
@@ -311,7 +320,9 @@ namespace Mercator  {
       
       cout.setf(ios::fixed, ios::floatfield);
       int oldPrec = cout.precision(2);
-      cout << "***Application runtimes (ms):" << endl;
+      cout << "*** " 
+	   << (appName ? appName : "Application") 
+	   << " runtimes (ms):" << endl;
       cout << "\tinit: " 
 	   << elapsedTime_init << "ms ("
 	   << elapsedTime_init*100.0/totalTime
@@ -328,6 +339,9 @@ namespace Mercator  {
 	   << totalTime << "ms" << endl;
       cout.precision(oldPrec);
 #endif    // if INSTRUMENT_TIME_HOST
+      
+      if (appName)
+	delete [] appName;
 
       // switch back to caller's device
       switchDevice(prevDeviceId);
@@ -354,8 +368,10 @@ namespace Mercator  {
     
   private:
 
+
     cudaStream_t stream;
     int deviceId;
+    char *appName;
     
     DevApp **deviceAppObjs;
     HostParamsT *hostParams;

--- a/runtime/hostCode/AppDriverBase.cuh
+++ b/runtime/hostCode/AppDriverBase.cuh
@@ -20,6 +20,8 @@ namespace Mercator  {
     virtual void runAsync(const HostParamsT *params) = 0;
     
     virtual void join() = 0;
+
+    virtual void setAppName(const char* name) = 0;
     
     // @brief synchronous run in terms of runAsync + join
     void run(const HostParamsT *params)


### PR DESCRIPTION
PR to merge the following changes
1) adds the Appname interface to code gen and appdriver
2) adds new cmake build rules to allow for passing of commandline vars into compilation. 

3) BREAKING CHANGE: this branch has a link time bug where duplicate symbols for _ZN8Mercator9Scheduler3runEv  are found when trying to build a driver with multiple Mercator apps inside. This only effects the DelaunayApp, as that is the only app to ever try constructing and linking shared libraries. Most likely this can be resolved in cmake after this merge, when its relevant again in the future. We should still merge here as that app is no longer in development. 